### PR TITLE
Make `Driver#sauceJobUpdate()` use the HTTPS endpoint

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -289,7 +289,7 @@ class Driver {
 
     await autoRequest(
       'PUT',
-      'http://' + auth + '@saucelabs.com/rest/v1/' + auth.split(':')[0] + '/jobs/' + session.sessionID,
+      'https://' + auth + '@saucelabs.com/rest/v1/' + auth.split(':')[0] + '/jobs/' + session.sessionID,
       {json: body},
     );
 


### PR DESCRIPTION
I'm not sure if this is due to a bug in `then-request`. It follows redirects but some parameters are ignored when hitting the HTTP version of the endpoint. For example, using

```js
{ name: 'url-parse', build: '43d8da23ce535a5d7ba8e9ebef084f5b' }
```

as `body` has not effect.

This seems to fix the issue.